### PR TITLE
Update version to 0.99.992 and add internal keywords

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.991
+Version: 0.99.992
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -23,7 +23,7 @@ targetRename <- function(inputNames) {
 
 #' Parameterize the base URL for the iLINCS API
 #'
-#'
+#' @keywords internal
 #' @return a fixed string URL
 .ilincsBaseUrl <- function() {
     "http://www.ilincs.org/api"
@@ -33,6 +33,7 @@ targetRename <- function(inputNames) {
 #'
 #' @param lib a string of libraries
 #'
+#' @keywords internal
 #' @return a boolean
 .validateLibrary <- function(lib) {
     lib %in% c("CP", "KD", "OE")
@@ -45,6 +46,7 @@ targetRename <- function(inputNames) {
 #'
 #' @param libs a character vector of libraries
 #'
+#' @keywords internal
 #' @return a boolean
 validateLibraries <- function(libs) {
     all(purrr::map_lgl(libs, .validateLibrary))
@@ -54,6 +56,7 @@ validateLibraries <- function(libs) {
 #'
 #' @param libs a character vector of libraries
 #'
+#' @keywords internal
 #' @return a stop if the libraries are invalid
 stopIfInvalidLibraries <- function(libs) {
     if (!validateLibraries(libs)) {
@@ -65,6 +68,7 @@ stopIfInvalidLibraries <- function(libs) {
 #'
 #' @param lib a string. One of "OE", "KD" or "CP"
 #'
+#' @keywords internal
 #' @return a tibble
 loadMetadata <- function(lib) {
     if (lib == "OE") {
@@ -83,6 +87,7 @@ loadMetadata <- function(lib) {
 #'
 #' @param lib A library name. Can be one of "OE", "KD" or "CP"
 #'
+#' @keywords internal
 #' @return A string with the associated library ID
 .return_library <- function(lib) {
     stopIfInvalidLibraries(lib)

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.991",
+  "version": "0.99.992",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -17,21 +17,30 @@
   "author": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
     },
     {
       "@type": "Person",
-      "givenName": ["Justin", "Fortune"],
+      "givenName": [
+        "Justin",
+        "Fortune"
+      ],
       "familyName": "Creeden",
       "email": "Justin.Creeden@rockets.utoledo.edu",
       "@id": "https://orcid.org/0000-0003-3123-8401"
     },
     {
       "@type": "Person",
-      "givenName": ["Evelyn", "Alden"],
+      "givenName": [
+        "Evelyn",
+        "Alden"
+      ],
       "familyName": "Bates",
       "email": "Evelyn.Bates@rockets.utoledo.edu",
       "@id": "https://orcid.org/0000-0002-4157-2481"
@@ -47,7 +56,10 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -349,10 +361,28 @@
   },
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
-  "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR", "r", "ilincs", "bioinformatics", "bioinformatics-pipeline"],
+  "keywords": [
+    "LINCS",
+    "iLINCS",
+    "drugrepurposing",
+    "drugdiscovery",
+    "transcriptomics",
+    "geneexpression",
+    "geneknockdown",
+    "geneoverexpression",
+    "chemicalperturbagen",
+    "drugfindR",
+    "r",
+    "ilincs",
+    "bioinformatics",
+    "bioinformatics-pipeline"
+  ],
   "fileSize": "2087.311KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/master/NEWS.md",
   "readme": "https://github.com/CogDisResLab/drugfindR/blob/devel/README.md",
-  "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
+  "contIntegration": [
+    "https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml",
+    "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"
+  ],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"
 }

--- a/man/dot-ilincsBaseUrl.Rd
+++ b/man/dot-ilincsBaseUrl.Rd
@@ -12,3 +12,4 @@ a fixed string URL
 \description{
 Parameterize the base URL for the iLINCS API
 }
+\keyword{internal}

--- a/man/dot-return_library.Rd
+++ b/man/dot-return_library.Rd
@@ -15,3 +15,4 @@ A string with the associated library ID
 \description{
 Return the internal iLINCS Library ID for a given library
 }
+\keyword{internal}

--- a/man/dot-validateLibrary.Rd
+++ b/man/dot-validateLibrary.Rd
@@ -15,3 +15,4 @@ a boolean
 \description{
 Check if the library is valid
 }
+\keyword{internal}

--- a/man/loadMetadata.Rd
+++ b/man/loadMetadata.Rd
@@ -15,3 +15,4 @@ a tibble
 \description{
 Load the correct metadata table
 }
+\keyword{internal}

--- a/man/stopIfInvalidLibraries.Rd
+++ b/man/stopIfInvalidLibraries.Rd
@@ -15,3 +15,4 @@ a stop if the libraries are invalid
 \description{
 Stop if the libraries are invalid
 }
+\keyword{internal}

--- a/man/validateLibraries.Rd
+++ b/man/validateLibraries.Rd
@@ -16,3 +16,4 @@ a boolean
 This function confirms that the library parameter
 is one of the allowed ones.
 }
+\keyword{internal}


### PR DESCRIPTION
### TL;DR

Updated package version and added internal keywords to utility functions.

### What changed?

- Incremented package version from 0.99.991 to 0.99.992 in DESCRIPTION and codemeta.json files.
- Added `@keywords internal` to several utility functions in utilities.R:
  - `.ilincsBaseUrl()`
  - `.validateLibrary()`
  - `validateLibraries()`
  - `stopIfInvalidLibraries()`
  - `loadMetadata()`
  - `.return_library()`
- Updated corresponding documentation files to include the internal keyword.

### How to test?

1. Check that the package version is correctly updated to 0.99.992.
2. Verify that the internal functions are not exposed in the public API documentation.
3. Ensure that the package builds and passes all existing tests without errors.

### Why make this change?

The addition of `@keywords internal` to utility functions helps to clearly distinguish between public and internal API functions. This improves package organization and prevents users from directly accessing functions that are meant for internal use only. The version update reflects these changes and keeps the package versioning consistent.