### PR TITLE
ci: update system repos, bump version to 0.99.1000

### DIFF
--- a/.github/workflows/create_github_release.yaml
+++ b/.github/workflows/create_github_release.yaml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Update system repositories
+        run: sudo apt-get update
       - name: Install system dependencies
         run: |
           sudo apt-get install -y libxml2-dev \

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.999
+Version: 0.99.1000
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.999",
+  "version": "0.99.1000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
### TL;DR

Updated system repositories and bumped package version.

### What changed?

- Added a step to update system repositories in the GitHub Actions workflow
- Increased the package version from 0.99.999 to 0.99.1000 in both DESCRIPTION and codemeta.json files

### How to test?

1. Run the GitHub Actions workflow to ensure it completes successfully with the new system repository update step
2. Verify that the package version is correctly updated to 0.99.1000 in both DESCRIPTION and codemeta.json files

### Why make this change?

Updating system repositories ensures that the latest package information is available during the workflow execution, potentially preventing issues with outdated package lists. The version bump is likely part of the package's development cycle, preparing for a new release or reflecting recent changes.