### PR TITLE
build: add pdf files t the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,5 @@ test.tsv
 !inst/extdata/*
 
 *.bak
+*.pdf
+*.jats

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1040
+Version: 0.99.1041
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1040",
+  "version": "0.99.1041",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -17,7 +17,10 @@
   "author": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -31,7 +34,10 @@
     },
     {
       "@type": "Person",
-      "givenName": ["Justin", "Fortune"],
+      "givenName": [
+        "Justin",
+        "Fortune"
+      ],
       "familyName": "Creeden",
       "email": "Justin.Creeden@rockets.utoledo.edu",
       "@id": "https://orcid.org/0000-0003-3123-8401"
@@ -40,7 +46,10 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -342,10 +351,28 @@
   },
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
-  "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR", "r", "ilincs", "bioinformatics", "bioinformatics-pipeline"],
+  "keywords": [
+    "LINCS",
+    "iLINCS",
+    "drugrepurposing",
+    "drugdiscovery",
+    "transcriptomics",
+    "geneexpression",
+    "geneknockdown",
+    "geneoverexpression",
+    "chemicalperturbagen",
+    "drugfindR",
+    "r",
+    "ilincs",
+    "bioinformatics",
+    "bioinformatics-pipeline"
+  ],
   "fileSize": "2166.634KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/master/NEWS.md",
   "readme": "https://github.com/CogDisResLab/drugfindR/blob/devel/README.md",
-  "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
+  "contIntegration": [
+    "https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml",
+    "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"
+  ],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"
 }


### PR DESCRIPTION
### TL;DR

Updated .gitignore to exclude PDF and JATS files and bumped package version.

### What changed?

- Added `*.pdf` and `*.jats` to the .gitignore file to prevent these file types from being tracked
- Incremented package version from 0.99.1040 to 0.99.1041 in both DESCRIPTION and codemeta.json files

### How to test?

1. Verify that newly created PDF and JATS files are not tracked by git
2. Confirm the version number is correctly updated in both DESCRIPTION and codemeta.json

### Why make this change?

PDF and JATS files are likely output or documentation files that don't need to be tracked in version control. Excluding them keeps the repository cleaner and prevents unnecessary large binary files from being committed. The version bump follows standard practice for tracking changes to the package.