### PR TITLE
feat: add the structure of the joss paper

### DIFF
--- a/.github/workflows/draft-paper.yaml
+++ b/.github/workflows/draft-paper.yaml
@@ -1,0 +1,28 @@
+name: Draft PDF
+on:
+  push:
+    paths:
+      - joss/
+      - .github/workflows/draft-paper.yaml
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: joss/paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1041
+Version: 0.99.1042
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1041",
+  "version": "0.99.1042",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -17,10 +17,7 @@
   "author": [
     {
       "@type": "Person",
-      "givenName": [
-        "Ali",
-        "Sajid"
-      ],
+      "givenName": ["Ali", "Sajid"],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -34,10 +31,7 @@
     },
     {
       "@type": "Person",
-      "givenName": [
-        "Justin",
-        "Fortune"
-      ],
+      "givenName": ["Justin", "Fortune"],
       "familyName": "Creeden",
       "email": "Justin.Creeden@rockets.utoledo.edu",
       "@id": "https://orcid.org/0000-0003-3123-8401"
@@ -46,10 +40,7 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": [
-        "Ali",
-        "Sajid"
-      ],
+      "givenName": ["Ali", "Sajid"],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -351,28 +342,10 @@
   },
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
-  "keywords": [
-    "LINCS",
-    "iLINCS",
-    "drugrepurposing",
-    "drugdiscovery",
-    "transcriptomics",
-    "geneexpression",
-    "geneknockdown",
-    "geneoverexpression",
-    "chemicalperturbagen",
-    "drugfindR",
-    "r",
-    "ilincs",
-    "bioinformatics",
-    "bioinformatics-pipeline"
-  ],
-  "fileSize": "2166.634KB",
+  "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR", "r", "ilincs", "bioinformatics", "bioinformatics-pipeline"],
+  "fileSize": "2339.707KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/master/NEWS.md",
   "readme": "https://github.com/CogDisResLab/drugfindR/blob/devel/README.md",
-  "contIntegration": [
-    "https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml",
-    "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"
-  ],
+  "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -103,6 +103,7 @@ acitretin
 Acitretin
 Acivicin
 Acknowledgements
+acknowledgements
 ACKR
 Aclidinium
 ACLY
@@ -189,6 +190,7 @@ ADRA
 ADRB
 ADRBK
 ADRM
+adsabs
 ADSL
 ADSS
 ADTRP
@@ -560,6 +562,8 @@ Arachidonyl
 ARAF
 ARAP
 Arbutin
+archivePrefix
+Archiveprefix
 ARCN
 Arctigenin
 Arecaidine
@@ -569,6 +573,7 @@ ARF
 ARFGAP
 ARFGEF
 ARFIP
+arfon
 ARFRP
 Arg
 ARG
@@ -623,6 +628,8 @@ ARV
 Arvanil
 ARVCF
 ARX
+arXiv
+ArXiv
 Arylmorpholine
 ASA
 ASAH
@@ -664,6 +671,10 @@ ASTE
 Astemizole
 ASTL
 ASTN
+astro
+astrometry
+astropy
+Astropy
 ASXL
 ASZ
 ATAC
@@ -936,6 +947,7 @@ BIK
 BIM
 Bimatoprost
 Bindarit
+Binney
 Binospirone
 bioc
 bioconductor
@@ -999,6 +1011,7 @@ BOK
 Boldine
 Bongkrekic
 Bonuten
+Booktitle
 Bopindolol
 BORA
 BORCS
@@ -1951,6 +1964,7 @@ CRYGN
 CRYGS
 CRYL
 CRYM
+cryptoes
 CRYZ
 CRYZL
 CSAD
@@ -2270,6 +2284,7 @@ Delanzomib
 Delcorine
 DELE
 DELEC
+deliverables
 DELq
 Deltaline
 Demeclocycline
@@ -2991,6 +3006,8 @@ epoxycholesterol
 EPP
 EPPIN
 EPPK
+eprint
+Eprint
 Eprosartan
 EPRS
 EPSTI
@@ -3327,10 +3344,13 @@ FIBP
 FIBRNPC
 FICD
 Fidaxomicin
+fidgit
+Fidgit
 FIGF
 FIGLA
 FIGN
 FIGNL
+Figshare
 fileSize
 FILIP
 FILNC
@@ -3567,6 +3587,8 @@ GABRR
 GACAT
 GADD
 GADL
+gady
+gaia
 GAK
 galantamine
 Galantamine
@@ -3994,6 +4016,7 @@ Haematoxylone
 HAGH
 HAGHL
 HAGLR
+Hahnel
 Halcinonide
 Halofantrine
 Halometasone
@@ -4009,6 +4032,7 @@ harmalan
 Harmine
 Harpagoside
 HARS
+harvard
 HASPIN
 HAUS
 HAV
@@ -4671,6 +4695,7 @@ ISX
 ISY
 ISYNA
 ITD
+iteratively
 ITFG
 ITGA
 ITGAD
@@ -6238,6 +6263,7 @@ NFKBIL
 NFKBIZ
 NFRKB
 NFS
+NFT
 NFU
 NFX
 NFXL
@@ -6411,6 +6437,7 @@ nosniff
 NOSTRIN
 NOTO
 NOTUM
+nov
 Novobiocin
 NOX
 NOXA
@@ -6589,6 +6616,7 @@ OCLN
 OCM
 OCRL
 OCSTAMP
+oct
 octadeca
 Octadecenamide
 Octadecylphenyl
@@ -7066,6 +7094,7 @@ PGPEP
 PGR
 PGRMC
 PGS
+ph
 PHA
 PHACTR
 PHAX
@@ -7520,6 +7549,7 @@ PRH
 Prilocaine
 PRIMA
 Primaquine
+primaryClass
 Primidone
 PRIMPOL
 PRKAA
@@ -7572,6 +7602,7 @@ PROCR
 Procyclidine
 Procysteine
 PRODH
+productizing
 Proglumide
 programmingLanguage
 Proimmune
@@ -9334,6 +9365,7 @@ TGOLN
 TGS
 TGX
 THADA
+Thaney
 THAP
 Thapsigargin
 THBD
@@ -9622,6 +9654,7 @@ TRDV
 TREH
 Trehalose
 TREM
+Tremaine
 TREML
 Tremorine
 Tremulacin
@@ -10117,6 +10150,7 @@ WFIKKN
 WFS
 WH
 WHAMM
+Whelan
 WHI
 WHRN
 WHSC

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -1,0 +1,59 @@
+@article{Pearson:2017,
+    url = {http://adsabs.harvard.edu/abs/2017arXiv170304627P},
+    Archiveprefix = {arXiv},
+    Author = {{Pearson}, S. and {Price-Whelan}, A.~M. and {Johnston}, K.~V.},
+    Eprint = {1703.04627},
+    Journal = {ArXiv e-prints},
+    Keywords = {Astrophysics - Astrophysics of Galaxies},
+    Month = mar,
+    Title = {{Gaps in Globular Cluster Streams: Pal 5 and the Galactic Bar}},
+    Year = 2017
+}
+
+@book{Binney:2008,
+    url = {http://adsabs.harvard.edu/abs/2008gady.book.....B},
+    Author = {{Binney}, J. and {Tremaine}, S.},
+    Booktitle = {Galactic Dynamics: Second Edition, by James Binney and Scott Tremaine.~ISBN 978-0-691-13026-2 (HB).~Published by Princeton University Press, Princeton, NJ USA, 2008.},
+    Publisher = {Princeton University Press},
+    Title = {{Galactic Dynamics: Second Edition}},
+    Year = 2008
+}
+
+@article{gaia,
+    author = {{Gaia Collaboration}},
+    title = "{The Gaia mission}",
+    journal = {Astronomy and Astrophysics},
+    archivePrefix = "arXiv",
+    eprint = {1609.04153},
+    primaryClass = "astro-ph.IM",
+    keywords = {space vehicles: instruments, Galaxy: structure, astrometry, parallaxes, proper motions, telescopes},
+    year = 2016,
+    month = nov,
+    volume = 595,
+    doi = {10.1051/0004-6361/201629272},
+    url = {http://adsabs.harvard.edu/abs/2016A%26A...595A...1G},
+}
+
+@article{astropy,
+    author = {{Astropy Collaboration}},
+    title = "{Astropy: A community Python package for astronomy}",
+    journal = {Astronomy and Astrophysics},
+    archivePrefix = "arXiv",
+    eprint = {1307.6212},
+    primaryClass = "astro-ph.IM",
+    keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+    year = 2013,
+    month = oct,
+    volume = 558,
+    doi = {10.1051/0004-6361/201322068},
+    url = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A}
+}
+
+@misc{fidgit,
+  author = {A. M. Smith and K. Thaney and M. Hahnel},
+  title = {Fidgit: An ungodly union of GitHub and Figshare},
+  year = {2020},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  url = {https://github.com/arfon/fidgit}
+}

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -1,0 +1,69 @@
+---
+title: "drugfindR: Investigate iLINCS for candidate repurposable drugs"
+tags:
+  - LINCS
+  - Bioinformatics
+  - Drug Repurposing
+authors:
+  - name: Ali Sajid Imami
+    affiliation: 1
+    orcid: 0000-0003-3684-3539
+    email: Ali.Sajid.Imami@gmail.com
+    equal-contrib: true
+    corresponding: yes
+  - name: Smita Sahay
+    affiliation: 1
+    orcid: 0009-0003-4377-8963
+    email: Smita.Sahay@rockets.utoledo.edu
+    equal-contrib: true
+  - name: Justin Fortune Creeden
+    affiliation: 3
+    orcid: 0000-0003-3123-8401
+    email: Justin.Creeden@rockets.utoledo.edu
+  - name: Robert Erne McCullumsmith
+    affiliation: "1, 2"
+    orcid: 0000-0003-3123-8401
+    email: Robert.McCullumsmith@utoledo.edu
+
+affiliations:
+  - name: "Department of Neurosciences and Psychiatry, University of Toledo, Toledo, OH, USA"
+    index: 1
+    ror: 01pbdzh19
+  - name: "Promedica Neurosciences Institute, Toledo, OH, USA"
+    index: 2
+    ror: 01k800776
+  - name: "Department of Psychiatry, University of California San Diego, La Jolla, Diego, CA, USA"
+    index: 3
+    ror: 0168r3w48
+
+date: April 15, 2025
+bibliography: paper.bib
+---
+
+# Summary
+
+__Add Summary Here__
+
+_We use our value-added brands to iteratively manage our digital nomad expectations. We thrive because of our end-to-end core asset and wholesale product culture. In the future, will you be able to globally align emerging markets in your business? We aim to virtually deep-dive our growth hacker by proactively engineering our cloud native customer-focused low hanging fruit._
+
+_Effectively impacting conservatively corporate user experiences is crucial to our holistic architecture. Our business monetizes milestones to intelligently and reliably reuse our competitive team player. Our business invests core competencies to strategically and ethically leverage our senior prince2 practitioner. It's critical that we give 110% when dynamically connecting standard setters._
+
+# Statement of Need
+
+__This is a Statement of need__
+
+
+
+_Going forward, our wholesale architecture will deliver value to stand-ups. Ethically touching base about transforming diversities will make us leaders in the holistic market focus industry. Globally touching base about productizing deliverables will make us leaders in the end-to-end game changer industry. Our business impacts user experiences to conservatively and virtually reuse our corporate executive search._
+
+_Our Best-Of-Breed Organic Growth solution offers milestones a suite of proactive offerings. We thrive because of our actionable visibility and innovative capability culture. Key players will take ownership of their creators by intelligently aligning world-class prince2 practitioners. We aim to reliably grow our stakeholder by effectively innovating our best-in-class immersive low hanging fruit._
+
+_Is your NFT prepared for competitive bandwidth growth? Our capability development lifecycle enables senior, mobile team players. Our Seamless Knowledge Transfer solution offers cryptoes a suite of company-wide offerings. Efficiencies will come from proactively calibrating our paradigm shifts._
+
+_We use our next-generation step-changes to iteratively manage our synergy expectations. In the future, will you be able to dynamically deep-dive core competencies in your business? Going forward, our long-term cloud will deliver value to standard setters. Is your smart contract prepared for cloud native driver growth?_
+
+# Acknowledgements
+
+_Enter acknowledgements here_
+
+# References


### PR DESCRIPTION
### TL;DR

Added GitHub workflow to automatically generate PDF drafts of the JOSS paper and set up initial JOSS paper structure.

### What changed?

- Added a new GitHub workflow (`draft-paper.yaml`) that automatically builds a PDF draft of the JOSS paper when changes are made to the paper files
- Created initial JOSS paper structure with:
  - `paper.md` template with author information, affiliations, and placeholder content
  - `paper.bib` with citation examples
- Updated package version from 0.99.1041 to 0.99.1042
- Added new terms to the wordlist to support JOSS paper development

### How to test?

1. Make a change to any file in the `joss/` directory
2. Push the changes to trigger the GitHub workflow
3. Check the workflow run in the Actions tab
4. Download the generated PDF artifact to verify the paper formatting

### Why make this change?

This change prepares the repository for submitting the package to the Journal of Open Source Software (JOSS), which requires a properly formatted paper describing the software. The automated workflow ensures that paper drafts are continuously built and available for review as the paper content is developed.