### PR TITLE
build: update renv dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1043
+Version: 0.99.1044
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1043",
+  "version": "0.99.1044",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -310,10 +310,28 @@
   },
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
-  "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR", "r", "ilincs", "bioinformatics", "bioinformatics-pipeline"],
+  "keywords": [
+    "LINCS",
+    "iLINCS",
+    "drugrepurposing",
+    "drugdiscovery",
+    "transcriptomics",
+    "geneexpression",
+    "geneknockdown",
+    "geneoverexpression",
+    "chemicalperturbagen",
+    "drugfindR",
+    "r",
+    "ilincs",
+    "bioinformatics",
+    "bioinformatics-pipeline"
+  ],
   "fileSize": "2339.95KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/master/NEWS.md",
   "readme": "https://github.com/CogDisResLab/drugfindR/blob/devel/README.md",
-  "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
+  "contIntegration": [
+    "https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml",
+    "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"
+  ],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"
 }

--- a/renv.lock
+++ b/renv.lock
@@ -4,23 +4,23 @@
     "Repositories": [
       {
         "Name": "BioCsoft",
-        "URL": "https://bioconductor.org/packages/3.19/bioc"
+        "URL": "https://bioconductor.org/packages/3.20/bioc"
       },
       {
         "Name": "BioCann",
-        "URL": "https://bioconductor.org/packages/3.19/data/annotation"
+        "URL": "https://bioconductor.org/packages/3.20/data/annotation"
       },
       {
         "Name": "BioCexp",
-        "URL": "https://bioconductor.org/packages/3.19/data/experiment"
+        "URL": "https://bioconductor.org/packages/3.20/data/experiment"
       },
       {
         "Name": "BioCworkflows",
-        "URL": "https://bioconductor.org/packages/3.19/workflows"
+        "URL": "https://bioconductor.org/packages/3.20/workflows"
       },
       {
         "Name": "BioCbooks",
-        "URL": "https://bioconductor.org/packages/3.19/books"
+        "URL": "https://bioconductor.org/packages/3.20/books"
       },
       {
         "Name": "CRAN",
@@ -29,7 +29,7 @@
     ]
   },
   "Bioconductor": {
-    "Version": "3.19"
+    "Version": "3.20"
   },
   "Packages": {
     "AnnotationDbi": {

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -1,5 +1,5 @@
 {
-  "bioconductor.version": "3.19",
+  "bioconductor.version": "3.20",
   "external.libraries": [],
   "ignored.packages": [],
   "package.dependency.fields": [


### PR DESCRIPTION
### TL;DR

Updated Bioconductor version from 3.19 to 3.20 and incremented package version to 0.99.1044.

### What changed?

- Incremented package version from 0.99.1043 to 0.99.1044 in both DESCRIPTION and codemeta.json
- Updated Bioconductor version from 3.19 to 3.20 in renv.lock and renv/settings.json
- Reformatted arrays in codemeta.json for better readability (keywords and contIntegration)

### How to test?

1. Verify the package builds correctly with the new Bioconductor version
2. Run tests to ensure compatibility with Bioconductor 3.20
3. Check that package dependencies resolve correctly with the updated repositories

### Why make this change?

This update ensures compatibility with the latest Bioconductor release (3.20). Keeping the package aligned with the current Bioconductor version is important for maintaining compatibility with the broader Bioconductor ecosystem and accessing the latest features and bug fixes in dependent packages.