### PR TITLE
ci: remove the graphite check-ci action

### DIFF
--- a/.github/workflows/create_github_release.yaml
+++ b/.github/workflows/create_github_release.yaml
@@ -11,20 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  optimize_ci:
-      runs-on: ubuntu-latest
-      outputs:
-        skip: ${{ steps.check_skip.outputs.skip }}
-      steps:
-        - name: Optimize CI
-          id: check_skip
-          uses: withgraphite/graphite-ci-action@main
-          with:
-            graphite_token: ${{secrets.GRAPHITE_TOKEN}}
   create-release:
     runs-on: ubuntu-latest
-    needs: [optimize_ci]
-    if: needs.optimize_ci.outputs.skip == 'false'
     permissions:
       contents: write
     outputs:
@@ -34,17 +22,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - name: Get most recent tag
-        id: get_tag
-        run: echo "TAG_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> "$GITHUB_ENV"
       - name: Create Release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          echo "Creating release for tag $TAG_VERSION"
-          gh release create $TAG_VERSION --title "Release $TAG_VERSION" --notes "Release $TAG_VERSION" --target ${{ github.ref }}
-          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+        run: ./utilities/create-github-release.sh
+
   create_release_artifacts:
     needs: [create-release]
     permissions:

--- a/.github/workflows/rworkflows.yml
+++ b/.github/workflows/rworkflows.yml
@@ -19,22 +19,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  optimize_ci:
-      runs-on: ubuntu-latest
-      outputs:
-        skip: ${{ steps.check_skip.outputs.skip }}
-      steps:
-        - name: Optimize CI
-          id: check_skip
-          uses: withgraphite/graphite-ci-action@main
-          with:
-            graphite_token: ${{secrets.GRAPHITE_TOKEN}}
   rworkflows:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }}
-    needs: [optimize_ci]
-    if: needs.optimize_ci.outputs.skip == 'false'
     strategy:
       fail-fast: ${{ false }}
       matrix:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,20 +9,8 @@ on:
 name: test-coverage
 
 jobs:
-  optimize_ci:
-      runs-on: ubuntu-latest
-      outputs:
-        skip: ${{ steps.check_skip.outputs.skip }}
-      steps:
-        - name: Optimize CI
-          id: check_skip
-          uses: withgraphite/graphite-ci-action@main
-          with:
-            graphite_token: ${{secrets.GRAPHITE_TOKEN}}
   test-coverage:
     runs-on: ubuntu-latest
-    needs: [optimize_ci]
-    if: needs.optimize_ci.outputs.skip == 'false'
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1048
+Version: 0.99.1049
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1048",
+  "version": "0.99.1049",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
### TL;DR

Removed Graphite CI optimization from GitHub workflows and improved the release creation process.

### What changed?

- Removed the `optimize_ci` job from all GitHub workflow files (create_github_release.yaml, rworkflows.yml, test-coverage.yaml)
- Replaced inline release creation commands with a script call to `./utilities/create-github-release.sh`
- Removed the manual tag version retrieval step
- Bumped package version from 0.99.1048 to 0.99.1049 in DESCRIPTION and codemeta.json

### How to test?

1. Verify that GitHub workflows run correctly without the Graphite CI optimization
2. Ensure the release creation script works by triggering a release workflow
3. Confirm the version bump is reflected in package metadata

### Why make this change?

The Graphite CI optimization was likely causing unnecessary complexity or issues in the CI pipeline. Moving the release creation logic to a dedicated script improves maintainability and allows for more complex release processes in the future without cluttering the workflow file.