### PR TITLE
ci: correct the concurrency of the release function

### DIFF
--- a/.github/workflows/create_github_release.yaml
+++ b/.github/workflows/create_github_release.yaml
@@ -8,7 +8,6 @@ name: Create Github Release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   create-release:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1049
+Version: 0.99.1050
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1049",
+  "version": "0.99.1050",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
### TL;DR

Removed `cancel-in-progress` flag from GitHub workflow and bumped package version.

### What changed?

- Removed the `cancel-in-progress: true` setting from the concurrency configuration in the GitHub release workflow
- Incremented package version from 0.99.1049 to 0.99.1050 in both DESCRIPTION and codemeta.json files

### How to test?

- Verify that the GitHub release workflow runs to completion without being canceled when multiple workflows are triggered
- Confirm that the package version is correctly updated in both DESCRIPTION and codemeta.json files

### Why make this change?

The `cancel-in-progress` flag was removed to ensure that release workflows are not canceled when multiple workflows are triggered concurrently. This is important for release workflows which should always complete once started. The version bump follows standard package development practices to track changes.