### PR TITLE
docs: change the vignette installation instruction to Bioc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1149
+Version: 0.99.1150
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1329
+Version: 0.99.1149
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1152
+Version: 0.99.1335
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1151
+Version: 0.99.1152
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1150
+Version: 0.99.1151
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: drugfindR
 Title: Investigate iLINCS for candidate repurposable drugs
-Version: 0.99.1335
+Version: 0.99.1336
 Authors@R: c(
     person(given = c("Ali", "Sajid"),
            family = "Imami",

--- a/R/investigateSignature.R
+++ b/R/investigateSignature.R
@@ -85,9 +85,9 @@ investigateSignature <- function(
   logfcColumn = "logFC",
   pvalColumn = "PValue",
   sourceName = "Input",
-  sourceCellLine = "NA",
-  sourceTime = "NA",
-  sourceConcentration = "NA"
+  sourceCellLine = NA,
+  sourceTime = NA,
+  sourceConcentration = NA
 ) {
     stopIfInvalidLibraries(outputLib) # nolint: object_usage_linter.
     if (missing(outputLib)) {

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1150",
+  "version": "0.99.1151",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1152",
+  "version": "0.99.1335",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1151",
+  "version": "0.99.1152",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1149",
+  "version": "0.99.1150",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -18,7 +18,10 @@
   "author": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -32,7 +35,10 @@
     },
     {
       "@type": "Person",
-      "givenName": ["Justin", "Fortune"],
+      "givenName": [
+        "Justin",
+        "Fortune"
+      ],
       "familyName": "Creeden",
       "email": "Justin.Creeden@rockets.utoledo.edu",
       "@id": "https://orcid.org/0000-0003-3123-8401"
@@ -41,7 +47,10 @@
   "contributor": [
     {
       "@type": "Person",
-      "givenName": ["Robert", "Erne"],
+      "givenName": [
+        "Robert",
+        "Erne"
+      ],
       "familyName": "McCullumsmith",
       "email": "Robert.McCullumsmith@utoledo.edu",
       "@id": "https://orcid.org/0000-0001-6921-7150"
@@ -50,7 +59,10 @@
   "funder": [
     {
       "@type": "Person",
-      "givenName": ["Robert", "Erne"],
+      "givenName": [
+        "Robert",
+        "Erne"
+      ],
       "familyName": "McCullumsmith",
       "email": "Robert.McCullumsmith@utoledo.edu",
       "@id": "https://orcid.org/0000-0001-6921-7150"
@@ -59,7 +71,10 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": ["Ali", "Sajid"],
+      "givenName": [
+        "Ali",
+        "Sajid"
+      ],
       "familyName": "Imami",
       "email": "Ali.Sajid.Imami@gmail.com",
       "@id": "https://orcid.org/0000-0003-3684-3539"
@@ -372,9 +387,23 @@
   },
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
-  "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR"],
+  "keywords": [
+    "LINCS",
+    "iLINCS",
+    "drugrepurposing",
+    "drugdiscovery",
+    "transcriptomics",
+    "geneexpression",
+    "geneknockdown",
+    "geneoverexpression",
+    "chemicalperturbagen",
+    "drugfindR"
+  ],
   "fileSize": "3744.658KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/main/NEWS.md",
-  "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
+  "contIntegration": [
+    "https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml",
+    "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"
+  ],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1329",
+  "version": "0.99.1149",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -373,7 +373,7 @@
   "applicationCategory": "Genomics",
   "isPartOf": "https://bioconductor.org",
   "keywords": ["LINCS", "iLINCS", "drugrepurposing", "drugdiscovery", "transcriptomics", "geneexpression", "geneknockdown", "geneoverexpression", "chemicalperturbagen", "drugfindR"],
-  "fileSize": "3744.653KB",
+  "fileSize": "3744.658KB",
   "releaseNotes": "https://github.com/CogDisResLab/drugfindR/blob/main/NEWS.md",
   "contIntegration": ["https://github.com/CogDisResLab/drugfindR/actions/workflows/rworkflows.yml", "https://app.codecov.io/gh/CogDisResLab/drugfindR?branch=devel"],
   "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html#experimental"

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/CogDisResLab/drugfindR",
   "issueTracker": "https://github.com/CogDisResLab/drugfindR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.99.1335",
+  "version": "0.99.1336",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -967,6 +967,7 @@ Binney
 Binospirone
 bioc
 bioconductor
+BioConductor
 BiocStyle
 biocthis
 biocViews

--- a/man/investigateSignature.Rd
+++ b/man/investigateSignature.Rd
@@ -17,9 +17,9 @@ investigateSignature(
   logfcColumn = "logFC",
   pvalColumn = "PValue",
   sourceName = "Input",
-  sourceCellLine = "NA",
-  sourceTime = "NA",
-  sourceConcentration = "NA"
+  sourceCellLine = NA,
+  sourceTime = NA,
+  sourceConcentration = NA
 )
 }
 \arguments{

--- a/tests/testthat/test-investigateSignature.R
+++ b/tests/testthat/test-investigateSignature.R
@@ -291,9 +291,9 @@ test_that("investigateSignature uses default metadata values", {
 
     # Check default values
     expect_identical(unique(result[["Source"]]), "Input")
-    expect_identical(unique(result[["SourceCellLine"]]), "NA")
-    expect_identical(unique(result[["SourceTime"]]), "NA")
-    expect_identical(unique(result[["SourceConcentration"]]), "NA")
+    expect_identical(unique(result[["SourceCellLine"]]), NA_character_)
+    expect_identical(unique(result[["SourceTime"]]), NA_character_)
+    expect_identical(unique(result[["SourceConcentration"]]), NA_character_)
 })
 
 test_that("investigateSignature adds SourceSignature column", {

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -330,10 +330,10 @@ The default is `"PValue"`.
 7. `sourceName`: The name of the source of the signature. The default is
 `"Input"`.
 8. `sourceCellLine`: The cell line of the source of the signature.
-The default is `"NA"`.
-9. `sourceTime`: The time of the source of the signature. The default is `"NA"`.
+The default is `NA`.
+9. `sourceTime`: The time of the source of the signature. The default is `NA`.
 10. `sourceConcentration`: The concentration of the source of the signature.
-The default is `"NA"`.
+The default is `NA`.
 
 
 ```{r investigateSignature}

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -88,8 +88,7 @@ and returns a list of consensus signature.
 
 For this case, we will use one of the signatures that was used in the paper
 ["Identification of candidate repurposable drugs to combat COVID - 19 using a
-signature - based approach" by O'Donovan, Imami, et al]
-(https://www.nature.com/articles/s41598-021-84044-9).
+signature - based approach" by O'Donovan, Imami, et al](https://www.nature.com/articles/s41598-021-84044-9).
 
 In that paper, the authors used the available gene expression data from cells
 infected with SARS-CoV-2 to identify potential

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -43,11 +43,11 @@ physiological reasons.
 
 ## Installation
 
-`drugfindR` can be installed from GitHub using the `devtools` package:
+`drugfindR` can be installed from BioConductor using the `BiocManager` package:
 
 ```{r install}
 #| eval: FALSE
-devtools::install_github("CogDisResLab/drugfindR") # nolint: nonportable_path_linter.
+BiocManager::install("drugfindR") # nolint: nonportable_path_linter.
 ```
 
 ## Use Cases

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -99,7 +99,7 @@ the `dCovid_diffexp.tsv` signature from the paper.
 
 ### Step 1: Get the Signature
 
-This signature is available with the package. Our first step is to download the
+This signature is available with the package. Our first step is to import the
 signature so we can work with it. The `read_tsv()` function from the `readr`
 package can be used to read the signature into R from a remote URL or a local
 file.

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -144,7 +144,7 @@ The default is `"PValue"`.
 ```{r prepareSignature}
 # Prepare the signature for analysis
 # The only thing that is different from the defaults is the gene_column
-# However, we will specify all three arguments for clarity
+# so we will specify that and rely on defaults for others.
 
 signature <- prepareSignature(diffexp,
     geneColumn = "hgnc_symbol"

--- a/vignettes/drugfindR.Rmd
+++ b/vignettes/drugfindR.Rmd
@@ -147,8 +147,7 @@ The default is `"PValue"`.
 # However, we will specify all three arguments for clarity
 
 signature <- prepareSignature(diffexp,
-    geneColumn = "hgnc_symbol",
-    logfcColumn = "logFC", pvalColumn = "PValue"
+    geneColumn = "hgnc_symbol"
 )
 
 # Take a look at the signature


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several updates focused on improving metadata handling, documentation clarity, and code style consistency in the `drugfindR` package. The most significant change is the shift from using the string `"NA"` to the proper R `NA` value for default metadata arguments, which affects the function interface, documentation, and tests. Additional updates include improvements to the package metadata files and user documentation.

**Metadata handling improvements:**
* Changed default values for `sourceCellLine`, `sourceTime`, and `sourceConcentration` in the `investigateSignature` function and its documentation from the string `"NA"` to the R value `NA` for more appropriate missing value representation (`R/investigateSignature.R`, `man/investigateSignature.Rd`, `vignettes/drugfindR.Rmd`). [[1]](diffhunk://#diff-7b7898f11b6da0b9db50f197e4f2c866b3436614e19524e8f399af4fa0d60e11L88-R90) [[2]](diffhunk://#diff-e1e1d8cdb57b6ac33d780da6e70f053add215916a93b8243331e413d421d1206L20-R22) [[3]](diffhunk://#diff-3b7454ce17100f703afc212421c453c948dbf436305ba17bf99290e687c918b9L335-R336)
* Updated related tests to expect `NA_character_` instead of `"NA"` for these metadata columns (`tests/testthat/test-investigateSignature.R`).

**Documentation and user guidance:**
* Updated the installation instructions in the vignette to recommend installing from BioConductor using `BiocManager::install()` instead of GitHub (`vignettes/drugfindR.Rmd`).
* Clarified and improved wording in the vignette, including fixing a markdown link and clarifying signature import instructions (`vignettes/drugfindR.Rmd`). [[1]](diffhunk://#diff-3b7454ce17100f703afc212421c453c948dbf436305ba17bf99290e687c918b9L91-R91) [[2]](diffhunk://#diff-3b7454ce17100f703afc212421c453c948dbf436305ba17bf99290e687c918b9L103-R102)
* Updated example usage to simplify arguments to `prepareSignature` in the vignette (`vignettes/drugfindR.Rmd`).

**Package metadata and style:**
* Updated package version from `0.99.1329` to `0.99.1335` in `DESCRIPTION` and `codemeta.json`, and made minor formatting improvements in `codemeta.json` (e.g., multi-line arrays for readability, updated file size). [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L11-R11) [[3]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L21-R24) [[4]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L35-R41) [[5]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L44-R53) [[6]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L53-R65) [[7]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L62-R77) [[8]](diffhunk://#diff-84554d7439cb1d112336deaccf858eb630c90e8fb331a783e0e31722c721c846L375-R407)

**Miscellaneous:**
* Added `BioConductor` (case-sensitive) to the `inst/WORDLIST` file for spelling or terminology consistency.

## Related Issues

This closes: #25 #26 #27 #28 and #76 

This triggers a second revision for #62 

## Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation
- [x] I have added/updated tests if applicable
- [x] All tests pass successfully
- [x] I have reviewed my code changes
- [x] I have addressed any feedback from code reviews